### PR TITLE
fix: add new email template for new envoiroment

### DIFF
--- a/conf/runtime.exs
+++ b/conf/runtime.exs
@@ -128,4 +128,5 @@ if email_expiry < 1,
 config :zenflows, Zenflows.Email,
 	email_from: fetch_env!("EMAIL_ADDR"),
 	api_key: fetch_env!("EMAIL_KEY"),
-	expiry: email_expiry
+	expiry: email_expiry,
+	email_uri: get_env_url.("EMAIL_URI", "http://localhost:3000/email/verify/")

--- a/src/zenflows/vf/person/domain.ex
+++ b/src/zenflows/vf/person/domain.ex
@@ -80,7 +80,7 @@ def request_email_verification(person, template) do
 		:interfacer_staging -> "https://interfacer-gui-staging.dyne.org/email/verify/"
 		:interfacer_testing -> "http://localhost:3000/email/verify/"
 		:interfacer_debugging -> "http://localhost:3000/email/verify/"
-		:interfacer_alpha -> "https://interfacer-test.dyne.im/email/verify/"
+		:interfacer_self -> Application.fetch_env(:zenflows, Zenflows.Email)[:email_uri]
 	end
 	Email.Domain.request_email_verification(person, url)
 end

--- a/src/zenflows/vf/person/domain.ex
+++ b/src/zenflows/vf/person/domain.ex
@@ -80,6 +80,7 @@ def request_email_verification(person, template) do
 		:interfacer_staging -> "https://interfacer-gui-staging.dyne.org/email/verify/"
 		:interfacer_testing -> "http://localhost:3000/email/verify/"
 		:interfacer_debugging -> "http://localhost:3000/email/verify/"
+		:interfacer_alpha -> "https://interfacer-test.dyne.im/email/verify/"
 	end
 	Email.Domain.request_email_verification(person, url)
 end

--- a/src/zenflows/vf/person/type.ex
+++ b/src/zenflows/vf/person/type.ex
@@ -49,6 +49,7 @@ enum :email_template do
 	value :interfacer_staging
 	value :interfacer_testing
 	value :interfacer_debugging
+	value :interfacer_alpha
 end
 
 @desc "A natural person."

--- a/src/zenflows/vf/person/type.ex
+++ b/src/zenflows/vf/person/type.ex
@@ -49,7 +49,7 @@ enum :email_template do
 	value :interfacer_staging
 	value :interfacer_testing
 	value :interfacer_debugging
-	value :interfacer_alpha
+	value :interfacer_self
 end
 
 @desc "A natural person."


### PR DESCRIPTION
I dont know if I did it right. This pr refers to: https://github.com/interfacerproject/interfacer-gui/pull/789
We are just trying to deploy a new environment and need a new template for the link of the verification email. Maybe the should be an env depending variables? 